### PR TITLE
fix: Изменение firstMessageId в firstSmartAppDataMid

### DIFF
--- a/cypress/integration/createAssistant.spec.ts
+++ b/cypress/integration/createAssistant.spec.ts
@@ -259,32 +259,43 @@ describe('Проверяем createAssistant', () => {
     });
 
     describe('window.__ASSISTANT_CLIENT__', () => {
-        it('Mid из window.appInitialData сохраняется и не изменяется', () => {
+        it('Mid smartAppData из window.appInitialData сохраняется и не изменяется. Mid другой команды не берётся', () => {
             const assistant = initAssistant({ ready: false });
             const [, , smartAppData] = initialData;
+            const commandNavigation = {
+                type: 'navigation',
+                navigation: { command: 'UP' },
+                sdk_meta: { mid: '7652349' },
+            };
 
-            window.appInitialData = [...initialData];
+            window.appInitialData = [commandNavigation, ...initialData];
             assistant.ready();
 
-            expect(window.__ASSISTANT_CLIENT__.firstMessageId).equal(smartAppData.sdk_meta.mid);
+            expect(window.__ASSISTANT_CLIENT__.firstSmartAppDataMid).equal(smartAppData.sdk_meta.mid);
             window.AssistantClient.onData({ ...smartAppData, sdk_meta: { mid: '234' } });
             window.AssistantClient.onData({ ...smartAppData, sdk_meta: { mid: '345' } });
-            expect(window.__ASSISTANT_CLIENT__.firstMessageId).equal(smartAppData.sdk_meta.mid);
+            expect(window.__ASSISTANT_CLIENT__.firstSmartAppDataMid).equal(smartAppData.sdk_meta.mid);
         });
 
-        it('При отсутствии команды с mid в window.appInitialData, mid берётся из следующих комманд и не изменяется', () => {
+        it('При отсутствии smartAppData в window.appInitialData, mid берётся из следующих команд и не изменяется. Mid другой команды не берётся', () => {
             const [character, insets, smartAppData] = initialData;
+            const commandNavigation = {
+                type: 'navigation',
+                navigation: { command: 'UP' },
+                sdk_meta: { mid: '7652349' },
+            };
             const assistant = initAssistant({ ready: false });
 
             window.appInitialData = [character, insets];
             assistant.ready();
 
-            expect(window.__ASSISTANT_CLIENT__.firstMessageId).equal(undefined);
+            expect(window.__ASSISTANT_CLIENT__.firstSmartAppDataMid).equal(undefined);
+            window.AssistantClient.onData({ ...commandNavigation, sdk_meta: { mid: '984' } });
             window.AssistantClient.onData(smartAppData);
-            expect(window.__ASSISTANT_CLIENT__.firstMessageId).equal(smartAppData.sdk_meta.mid);
+            expect(window.__ASSISTANT_CLIENT__.firstSmartAppDataMid).equal(smartAppData.sdk_meta.mid);
             window.AssistantClient.onData({ ...smartAppData, sdk_meta: { mid: '234' } });
             window.AssistantClient.onData({ ...smartAppData, sdk_meta: { mid: '345' } });
-            expect(window.__ASSISTANT_CLIENT__.firstMessageId).equal(smartAppData.sdk_meta.mid);
+            expect(window.__ASSISTANT_CLIENT__.firstSmartAppDataMid).equal(smartAppData.sdk_meta.mid);
         });
     });
 });

--- a/global.d.ts
+++ b/global.d.ts
@@ -7,7 +7,7 @@ export declare global {
     interface Window {
         __ASSISTANT_CLIENT__: {
             version: string;
-            firstMessageId?: string;
+            firstSmartAppDataMid?: string;
         };
         webkitAudioContext?: new () => AudioContext;
     }

--- a/src/appInitialData.ts
+++ b/src/appInitialData.ts
@@ -35,7 +35,7 @@ export const appInitialData = (() => {
             return [...pulled];
         },
         /**
-         * Прочитать appInitialData. Только возвращает текущее состояние initialData
+         * Прочитать appInitialData
          * @returns Массив комманд
          */
         get: () => [...(window.appInitialData || [])],

--- a/src/createAssistant.ts
+++ b/src/createAssistant.ts
@@ -183,11 +183,11 @@ export const createAssistant = <A extends AssistantSmartAppData>({
         }
     };
 
-    const saveFirstMessageId = (mid: string) => {
+    const saveFirstSmartAppDataMid = (mid: string) => {
         // eslint-disable-next-line no-underscore-dangle
-        if (typeof window.__ASSISTANT_CLIENT__.firstMessageId === 'undefined') {
+        if (typeof window.__ASSISTANT_CLIENT__.firstSmartAppDataMid === 'undefined') {
             // eslint-disable-next-line no-underscore-dangle
-            window.__ASSISTANT_CLIENT__.firstMessageId = mid;
+            window.__ASSISTANT_CLIENT__.firstSmartAppDataMid = mid;
         }
     };
 
@@ -197,8 +197,8 @@ export const createAssistant = <A extends AssistantSmartAppData>({
                 return;
             }
 
-            if ((command.sdk_meta?.mid || '-1') !== '-1') {
-                saveFirstMessageId(command.sdk_meta?.mid!);
+            if (command.type === 'smart_app_data' && (command.sdk_meta?.mid || '-1') !== '-1') {
+                saveFirstSmartAppDataMid(command.sdk_meta?.mid!);
             }
 
             /// фильтр команды 'назад'
@@ -251,10 +251,13 @@ export const createAssistant = <A extends AssistantSmartAppData>({
     };
 
     const readyFn = () => {
-        const firstMid = appInitialData.get().find((c) => (c.sdk_meta?.mid || '-1') !== '-1')?.sdk_meta?.mid || '-1';
+        const firstSmartAppDataMid =
+            appInitialData.get().find((c) => {
+                return c.type === 'smart_app_data' && (c.sdk_meta?.mid || '-1') !== '-1';
+            })?.sdk_meta?.mid || '-1';
 
-        if (firstMid !== '-1') {
-            saveFirstMessageId(firstMid);
+        if (firstSmartAppDataMid !== '-1') {
+            saveFirstSmartAppDataMid(firstSmartAppDataMid);
         }
 
         appInitialData.commit();


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.2.1--canary.14.70607eadf47f4c1cf4621e528bd951ea809ce4dd.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/client@1.2.1--canary.14.70607eadf47f4c1cf4621e528bd951ea809ce4dd.0
  # or 
  yarn add @salutejs/client@1.2.1--canary.14.70607eadf47f4c1cf4621e528bd951ea809ce4dd.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
