### PR TITLE
Включение автослушания после мьюта

### DIFF
--- a/src/assistantSdk/voice/voice.ts
+++ b/src/assistantSdk/voice/voice.ts
@@ -39,9 +39,7 @@ const createVoiceSettings = (listener: ReturnType<typeof createVoiceListener>) =
 
         subscribers.push(
             listener.on('status', (status) => {
-                const willBeDubbing = voicePlayer && !settings.disableDubbing;
-
-                if (status === 'stopped' && !willBeDubbing) {
+                if (status === 'stopped') {
                     tryApply();
                 }
             }),


### PR DESCRIPTION
Не срабатывает автослушание после мьюта, тк было условие `!disableDubbing`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.4.2--canary.21.4b0afc2d3e3d9ee79b494d3091201ca90f2f9e73.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/client@1.4.2--canary.21.4b0afc2d3e3d9ee79b494d3091201ca90f2f9e73.0
  # or 
  yarn add @salutejs/client@1.4.2--canary.21.4b0afc2d3e3d9ee79b494d3091201ca90f2f9e73.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
