### PR TITLE
fix: Теперь разные команды могут иметь один mid и будут заэмичены

### DIFF
--- a/cypress/integration/createAssistant.spec.ts
+++ b/cypress/integration/createAssistant.spec.ts
@@ -258,6 +258,30 @@ describe('Проверяем createAssistant', () => {
         expect(window.AssistantHost.ready).to.calledOnce;
     });
 
+    it('Не эмитить команды повторяющиеся из appInitialData, эмитить разные команды с одним mid', () => {
+        const stubOnCommand = cy.stub();
+        const assistant = initAssistant({ ready: false });
+        const userCommand1 = {
+            type: 'smart_app_data',
+            smart_app_data: { command: 'USER_COMMAND_1' },
+            sdk_meta: { mid: '112233' },
+        };
+        const userCommand2 = {
+            type: 'smart_app_data',
+            smart_app_data: { command: 'USER_COMMAND_2' },
+            sdk_meta: { mid: '112233' },
+        };
+
+        window.appInitialData = [...initialData, userCommand1];
+
+        assistant.ready();
+        assistant.on('command', (command) => stubOnCommand(command.command));
+
+        window.AssistantClient.onData(userCommand1);
+        window.AssistantClient.onData(userCommand2);
+        expect(stubOnCommand).to.be.calledOnceWith(userCommand2.smart_app_data.command);
+    });
+
     describe('window.__ASSISTANT_CLIENT__', () => {
         it('Mid smartAppData из window.appInitialData сохраняется и не изменяется. Mid другой команды не берётся', () => {
             const assistant = initAssistant({ ready: false });


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.5.1--canary.28.a154d60a846d831ade245d216012edd7848205df.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/client@1.5.1--canary.28.a154d60a846d831ade245d216012edd7848205df.0
  # or 
  yarn add @salutejs/client@1.5.1--canary.28.a154d60a846d831ade245d216012edd7848205df.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
