### PR TITLE
fix: Исправлен перезапуск канваса при получении команды навигации

### DIFF
--- a/src/assistantSdk/assistant.ts
+++ b/src/assistantSdk/assistant.ts
@@ -337,7 +337,7 @@ export const createAssistant = ({ getMeta, ...configuration }: VpsConfiguration 
                 }
 
                 // по-умолчанию activate_app_info: true
-                if (mesAppInfo && activate_app_info !== false) {
+                if (activate_app_info !== false && mesAppInfo && mesAppInfo.applicationId !== app.info.applicationId) {
                     emit('app', { type: 'run', app: mesAppInfo });
                 }
 


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.13.1--canary.72.19db6349b32c78574e277bf27bf8504eb797cd22.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/client@1.13.1--canary.72.19db6349b32c78574e277bf27bf8504eb797cd22.0
  # or 
  yarn add @salutejs/client@1.13.1--canary.72.19db6349b32c78574e277bf27bf8504eb797cd22.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
