### PR TITLE
fix: Добавлен ретрай для вызова AssistantHost.ready()

### DIFF
--- a/cypress/integration/createAssistant.spec.ts
+++ b/cypress/integration/createAssistant.spec.ts
@@ -396,6 +396,53 @@ describe('Проверяем createAssistant', () => {
             });
     });
 
+    it('ready выбрасывает ошибку, если window.AssistantHost.ready не функция', (done) => {
+        const readyBefore = window.AssistantHost.ready;
+        const assistant = initAssistant({ ready: false });
+        const errorMessage = 'window.AssistantHost is not ready.';
+
+        window.AssistantHost.ready = null;
+
+        assistant.ready().catch((err) => {
+            window.AssistantHost.ready = readyBefore;
+
+            expect(err.message.startsWith(errorMessage), `Получили ${errorMessage}`).to.be.true;
+            done();
+        });
+    });
+
+    it('ready выбрасывает ошибку, если window.AssistantHost === undefined', (done) => {
+        const assistantHostBefore = window.AssistantHost;
+        const assistant = initAssistant({ ready: false });
+        const errorMessage = 'window.AssistantHost is not ready.';
+
+        window.AssistantHost = undefined;
+
+        assistant.ready().catch((err) => {
+            window.AssistantHost = assistantHostBefore;
+
+            expect(err.message.startsWith(errorMessage), `Получили ${errorMessage}`).to.be.true;
+            done();
+        });
+    });
+
+    it('ready делает несколько попыток вызова window.AssistantHost.ready', (done) => {
+        const readyBefore = window.AssistantHost.ready;
+        const assistant = initAssistant({ ready: false });
+
+        window.AssistantHost.ready = null;
+
+        assistant.ready();
+
+        (async () => {
+            window.AssistantHost.ready = () => {
+                window.AssistantHost.ready = readyBefore;
+    
+                done();
+            };
+        })();
+    });
+
     describe('window.__ASSISTANT_CLIENT__', () => {
         it('Mid smartAppData из window.appInitialData сохраняется и не изменяется. Mid другой команды не берётся', () => {
             const assistant = initAssistant({ ready: false });


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.17.1--canary.81.bc3f4578c977488a4c88aba0215e39de611194d9.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/client@1.17.1--canary.81.bc3f4578c977488a4c88aba0215e39de611194d9.0
  # or 
  yarn add @salutejs/client@1.17.1--canary.81.bc3f4578c977488a4c88aba0215e39de611194d9.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
