### PR TITLE
fix: убран пропуск первых слов при listen в сафари

### DIFF
--- a/src/assistantSdk/voice/listener/navigatorAudioProvider.ts
+++ b/src/assistantSdk/voice/listener/navigatorAudioProvider.ts
@@ -99,6 +99,7 @@ const createAudioRecorder = (
                 const dataWithVoice = new Uint8Array(data).some((voiceData) => voiceData > 0);
 
                 if (!IS_SAFARI || dataWithVoice) {
+                    resolve(stop);
                     cb(data, last);
                 }
 
@@ -108,7 +109,6 @@ const createAudioRecorder = (
             };
 
             processor.addEventListener('audioprocess', listener);
-            processor.addEventListener('audioprocess', () => resolve(stop), { once: true });
 
             input.connect(processor);
             processor.connect(context.destination);


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.18.1--canary.101.14bf275e9ca93954d3c84364364e4ec4efc64551.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/client@1.18.1--canary.101.14bf275e9ca93954d3c84364364e4ec4efc64551.0
  # or 
  yarn add @salutejs/client@1.18.1--canary.101.14bf275e9ca93954d3c84364364e4ec4efc64551.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
