### PR TITLE
fix: change postMessage target from top to parent

### DIFF
--- a/src/createAssistant.ts
+++ b/src/createAssistant.ts
@@ -50,7 +50,7 @@ const excludeTags = ['A', 'AUDIO', 'BUTTON', 'INPUT', 'OPTION', 'SELECT', 'TEXTA
 
 function inIframe() {
     try {
-        return window.self !== window.top;
+        return window.self !== window.parent;
     } catch (e) {
         return true;
     }
@@ -58,7 +58,7 @@ function inIframe() {
 
 if (typeof window !== 'undefined' && inIframe()) {
     const postMessage = (action: AssistantPostMessage) => {
-        window.top?.postMessage(JSON.stringify(action), '*');
+        window.parent?.postMessage(JSON.stringify(action), '*');
     };
 
     const historyBack = () => {


### PR DESCRIPTION
Заменил отправку сообщения из window.top в window.parent на случай если есть больше одной вложенности окон.