### PR TITLE
fix: Использовать window.parent вместо top

### DIFF
--- a/src/createAssistant.ts
+++ b/src/createAssistant.ts
@@ -50,7 +50,7 @@ const excludeTags = ['A', 'AUDIO', 'BUTTON', 'INPUT', 'OPTION', 'SELECT', 'TEXTA
 
 function inIframe() {
     try {
-        return window.self !== window.top;
+        return window.self !== window.parent;
     } catch (e) {
         return true;
     }
@@ -58,7 +58,7 @@ function inIframe() {
 
 if (typeof window !== 'undefined' && inIframe()) {
     const postMessage = (action: AssistantPostMessage) => {
-        window.top?.postMessage(JSON.stringify(action), '*');
+        window.parent?.postMessage(JSON.stringify(action), '*');
     };
 
     const historyBack = () => {


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.19.1--canary.104.3b4d4fafb63ae87bb319434b891cfb23932e2b93.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/client@1.19.1--canary.104.3b4d4fafb63ae87bb319434b891cfb23932e2b93.0
  # or 
  yarn add @salutejs/client@1.19.1--canary.104.3b4d4fafb63ae87bb319434b891cfb23932e2b93.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
