### PR TITLE
fix: фикс версии uuid для ie

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "lodash.clonedeep": "4.5.0",
                 "long": "5.2.3",
                 "protobufjs": "7.2.3",
-                "uuid": "9.0.0"
+                "uuid": "8.3.2"
             },
             "devDependencies": {
                 "@auto-it/conventional-commits": "^10.25.0",
@@ -17290,9 +17290,9 @@
             "dev": true
         },
         "node_modules/uuid": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-            "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
             "bin": {
                 "uuid": "dist/bin/uuid"
             }
@@ -31171,9 +31171,9 @@
             "dev": true
         },
         "uuid": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-            "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         },
         "validate-npm-package-license": {
             "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "lodash.clonedeep": "4.5.0",
         "long": "5.2.3",
         "protobufjs": "7.2.3",
-        "uuid": "9.0.0"
+        "uuid": "8.3.2"
     },
     "browserslist": [
         "last 1 Chrome versions"


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.21.2--canary.110.2e18331a46a42c286d84dc486f091a8504050a86.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/client@1.21.2--canary.110.2e18331a46a42c286d84dc486f091a8504050a86.0
  # or 
  yarn add @salutejs/client@1.21.2--canary.110.2e18331a46a42c286d84dc486f091a8504050a86.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
