### PR TITLE
fix: DIALOG-апп должен переключаться на ассистента

### DIFF
--- a/src/typings.ts
+++ b/src/typings.ts
@@ -471,7 +471,6 @@ export type SystemMessageDataType = {
     activate_app_info?: boolean;
     app_info?: AppInfo;
     auto_listening: boolean;
-    finished?: boolean;
     items?: Array<ItemType>;
     suggestions?: Suggestions;
     hints?: Hints;


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.24.1--canary.149.98ef32bfe19fdcd56b2dd341742238e7568a2fdc.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/client@1.24.1--canary.149.98ef32bfe19fdcd56b2dd341742238e7568a2fdc.0
  # or 
  yarn add @salutejs/client@1.24.1--canary.149.98ef32bfe19fdcd56b2dd341742238e7568a2fdc.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
