### PR TITLE
fix: добавил default_character в мету

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,7 @@ module.exports = {
     parser: '@typescript-eslint/parser',
     plugins: ['import', 'prettier', 'cypress', '@typescript-eslint'],
     rules: {
-        camelcase: 'error',
+        camelcase: ['error', { allow: ['default_character'] }],
         'spaced-comment': ['error', 'always', { markers: ['/'] }], /// разрешаем ts-require directive
         'comma-dangle': ['error', 'always-multiline'],
         'arrow-parens': ['error', 'always'],


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.29.1--canary.168.cdc0861a2c7075a05027a77b75d176c2bf3fe2af.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/client@1.29.1--canary.168.cdc0861a2c7075a05027a77b75d176c2bf3fe2af.0
  # or 
  yarn add @salutejs/client@1.29.1--canary.168.cdc0861a2c7075a05027a77b75d176c2bf3fe2af.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
