### PR TITLE
fix: Перенести тип для __ASSISTANT_CLIENT__ в AssistantWindow

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -5,10 +5,6 @@ declare global {
     interface Window extends AssistantWindow {}
 
     interface Window {
-        __ASSISTANT_CLIENT__: {
-            version: string;
-            firstSmartAppDataMid?: string;
-        };
         webkitAudioContext?: new () => AudioContext;
     }
 }

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -393,6 +393,11 @@ export interface AssistantWindow {
     __dangerouslySendVoiceMessage?: (message: string) => void;
     __dangerouslyGetAssistantAppState?: () => AssistantAppState;
     __dangerouslySendTextMessage?: (text: string) => void;
+
+    __ASSISTANT_CLIENT__: {
+        version: string;
+        firstSmartAppDataMid?: string;
+    };
 }
 
 export interface AssistantBackgroundApp {


### PR DESCRIPTION
Closes #23 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.28.1--canary.170.2244b0cf8e1fb76a22cd4dbd733c14e36e4beb00.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/client@1.28.1--canary.170.2244b0cf8e1fb76a22cd4dbd733c14e36e4beb00.0
  # or 
  yarn add @salutejs/client@1.28.1--canary.170.2244b0cf8e1fb76a22cd4dbd733c14e36e4beb00.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
