### PR TITLE
fix: Исправлен релиз пакета при мёрже в мастер

### DIFF
--- a/.github/workflows/bundle-report.yml
+++ b/.github/workflows/bundle-report.yml
@@ -5,12 +5,10 @@ on:
     branches:
       - '*'
 
-  push:
-    branches:
-      - 'master'
+  merge_group:
 
 env:
-  merging: ${{ github.event_name == 'push' }}
+  merging: ${{ github.event_name == 'merge_group' }}
 
 jobs:
   main:


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.32.3--canary.188.6f1c10c6b0e00d96070540642412fa01405d6b8f.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/client@1.32.3--canary.188.6f1c10c6b0e00d96070540642412fa01405d6b8f.0
  # or 
  yarn add @salutejs/client@1.32.3--canary.188.6f1c10c6b0e00d96070540642412fa01405d6b8f.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
