### PR TITLE
fix: Не использовать персонажей из salutejs/scenario

### DIFF
--- a/src/typings.ts
+++ b/src/typings.ts
@@ -42,10 +42,11 @@ export {
     PermissionType,
     PermissionStatus,
     Character,
-    CharacterId,
     Hints,
     ServerAction,
 } from '@salutejs/scenario';
+
+export type CharacterId = 'sber' | 'eva' | 'joy';
 
 export type Surface = 'SBERBOX' | 'STARGATE' | 'SATELLITE' | 'COMPANION' | 'SBOL' | 'TV' | 'TV_HUAWEI' | 'TIME';
 


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.32.6--canary.195.e2dc657ce734ea30cc147ad501e327152f23bd9d.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/client@1.32.6--canary.195.e2dc657ce734ea30cc147ad501e327152f23bd9d.0
  # or 
  yarn add @salutejs/client@1.32.6--canary.195.e2dc657ce734ea30cc147ad501e327152f23bd9d.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
