### PR TITLE
fix: передавать строку в setHeaderButtons

### DIFF
--- a/cypress/integration/createAssistant.spec.ts
+++ b/cypress/integration/createAssistant.spec.ts
@@ -230,7 +230,7 @@ describe('Проверяем createAssistant', () => {
         ];
         const assistant = initAssistant();
         assistant.setHeaderButtons(headerButtons);
-        expect(window.AssistantHost.setHeaderButtons).to.calledWith(headerButtons);
+        expect(window.AssistantHost.setHeaderButtons).to.calledWith(JSON.stringify(headerButtons));
     });
 
     it("Проверяем фильтрацию system.command = 'back' - не должна попадать в onData", () => {

--- a/src/createAssistant.ts
+++ b/src/createAssistant.ts
@@ -85,8 +85,11 @@ if (typeof window !== 'undefined' && inIframe()) {
         sendText(message: string) {
             postMessage({ type: 'sendText', payload: message });
         },
-        setHeaderButtons(headerButtons: SystemMessageHeaderByttonsType) {
-            postMessage({ type: 'setHeaderButtons', payload: JSON.stringify(headerButtons) });
+        setHeaderButtons(headerButtons: string) {
+            postMessage({
+                type: 'setHeaderButtons',
+                payload: typeof headerButtons === 'string' ? headerButtons : JSON.stringify(headerButtons),
+            });
         },
     };
 
@@ -411,7 +414,7 @@ export const createAssistant = <A extends AssistantSmartAppData>({
                 throw new Error('setHeaderButtons не поддерживается в данной версии клиента');
             }
 
-            window.AssistantHost?.setHeaderButtons(headerButtons);
+            window.AssistantHost?.setHeaderButtons(JSON.stringify(headerButtons));
         },
         ready: readyFn,
     };

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -383,7 +383,7 @@ export interface AssistantHost {
     sendText: (message: string) => void;
     setSuggests: (suggest: string) => void;
     setHints: (hints: string) => void;
-    setHeaderButtons?: (headerButtons: SystemMessageHeaderByttonsType) => void;
+    setHeaderButtons?: (headerButtons: string) => void;
 }
 
 export interface AssistantWindow {


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.33.2--canary.198.26c4207fa73d180e28e31248a316508b4baf5cfe.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/client@1.33.2--canary.198.26c4207fa73d180e28e31248a316508b4baf5cfe.0
  # or 
  yarn add @salutejs/client@1.33.2--canary.198.26c4207fa73d180e28e31248a316508b4baf5cfe.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
