### PR TITLE
fix: фикс версии protobuf

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "@salutejs/scenario": "^0.38.0",
                 "lodash.clonedeep": "^4.5.0",
                 "long": "^5.2.3",
-                "protobufjs": "7.2.6",
+                "protobufjs": "^7.2.6",
                 "uuid": "^8.3.2"
             },
             "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "@salutejs/scenario": "^0.38.0",
         "lodash.clonedeep": "^4.5.0",
         "long": "^5.2.3",
-        "protobufjs": "7.2.6",
+        "protobufjs": "^7.2.6",
         "uuid": "^8.3.2"
     },
     "browserslist": [


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.33.5--canary.210.fb420a6044a50c60bdc66a846fac345a6cf644f9.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/client@1.33.5--canary.210.fb420a6044a50c60bdc66a846fac345a6cf644f9.0
  # or 
  yarn add @salutejs/client@1.33.5--canary.210.fb420a6044a50c60bdc66a846fac345a6cf644f9.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
