### PR TITLE
fix: Добавить недостающие файлы в пакет

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -63,6 +63,14 @@ export default [
                         src: 'src/proto/*.d.ts',
                         dest: 'dist/proto',
                     },
+                    {
+                        src: 'src/assistantSdk/voice/recognizers/asr/*.d.ts',
+                        dest: 'dist/assistantSdk/voice/recognizers/asr'
+                    },
+                    {
+                        src: 'src/assistantSdk/voice/recognizers/mtt/*.d.ts',
+                        dest: 'dist/assistantSdk/voice/recognizers/mtt'
+                    },
                 ],
             }),
         ],


### PR DESCRIPTION

Данные файлы не копировались при сборке в директорию dist из-за чего отсутствовали в итоговом пакете.

Их отсутствие приводит к ошибкам при использовании `@salutejs/client` с опцией `"skipLibCheck": false` в tsconfig.json (значение по умолчанию).
