### PR TITLE
fix: update default settings after first connection

### DIFF
--- a/src/assistantSdk/client/protocol.ts
+++ b/src/assistantSdk/client/protocol.ts
@@ -179,8 +179,8 @@ export const createProtocol = (
         return getHistoryRequestOriginal({
             device: currentSettings.device || null,
             uuid: {
-                userId: data.uuid?.userId || userId,
-                userChannel: data.uuid?.userChannel || userChannel,
+                userId: data.uuid?.userId || configuration.userId,
+                userChannel: data.uuid?.userChannel || configuration.userChannel,
             },
             history: { ...(data.history || {}) },
         });
@@ -266,8 +266,8 @@ export const createProtocol = (
 
                 sendInitialSettings(
                     {
-                        userId,
-                        userChannel,
+                        userId: configuration.userId,
+                        userChannel: configuration.userChannel,
                         device: currentSettings.device,
                         settings: currentSettings.settings,
                         locale: version > 3 ? currentSettings.locale : undefined,


### PR DESCRIPTION
Исправлена ошибка при которой после подключения невозможно поменять userId и userChannel. Реконнект происходил с инициализирующими параметрами из за замыкания